### PR TITLE
composer.json comma error

### DIFF
--- a/server/composer.json
+++ b/server/composer.json
@@ -12,7 +12,7 @@
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.2",
         "laravel/tinker": "^2.0",
-        "tymon/jwt-auth": "^1.0",
+        "tymon/jwt-auth": "^1.0"
     },
     "require-dev": {
         "facade/ignition": "^1.4",


### PR DESCRIPTION
- Takes off a comma incorrectly added in the json file structure of composer
- Related to issue #1 